### PR TITLE
:bug: Bug and style fixes

### DIFF
--- a/MinecraftDev-2022.2/src/main/kotlin/platform/bukkit/creator/BukkitProjectCreator.kt
+++ b/MinecraftDev-2022.2/src/main/kotlin/platform/bukkit/creator/BukkitProjectCreator.kt
@@ -137,8 +137,10 @@ open class BukkitDependenciesStep(
                         "org.spigotmc",
                         "spigot-api",
                         "$mcVersion-R0.1-SNAPSHOT",
+                        "provided"
                     )
                 )
+
                 addSonatype(buildSystem.repositories)
             }
             else -> {}
@@ -168,6 +170,12 @@ open class BukkitDependenciesStep(
                 "spigotmc-repo",
                 "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
             )
+        )
+        list.add(
+            BuildRepository(
+                "jitpack.io",
+                "https://jitpack.io"
+                )
         )
     }
 }

--- a/MinecraftDev-2022.2/src/main/kotlin/util/JavaVersions.kt
+++ b/MinecraftDev-2022.2/src/main/kotlin/util/JavaVersions.kt
@@ -17,11 +17,11 @@ object JavaVersions {
 
     fun requiredJavaVersion(comboBoxJavaVersion: String) = when (comboBoxJavaVersion) {
         "8" -> JavaVersion.parse("8").toFeatureString()
-        else -> {"17"}
+        else -> {"19"}
     }
 
     fun addJavaVersionBoxItems(javaVersionBox: JComboBox<String>) {
         javaVersionBox.addItem("8")
-        javaVersionBox.addItem("17")
+        javaVersionBox.addItem("19")
     }
 }

--- a/MinecraftDev-2022.2/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit Main Class.java.ft
+++ b/MinecraftDev-2022.2/src/main/resources/fileTemplates/j2ee/bukkit/Bukkit Main Class.java.ft
@@ -7,10 +7,9 @@ public final class ${CLASS_NAME} extends JavaPlugin {
     @Override
     public void onEnable() {
         // Plugin startup logic
-        System.out.println("${CLASS_NAME} is enabled");
+        getLogger().info("${CLASS_NAME} is enabled!");
 
-
-        }
+    }
 
     @Override
     public void onDisable() {


### PR DESCRIPTION
:bug: Resolved a bug where the dependencies of a Minecraft Plugin's JAR were filled with unnecessary libraries. 

:speech_balloon: Changed `System.out.println()` call in the Bukkit Main class template to `getLogger().info()` to meet better standards.

:zap: Bumped the supported Java version from 17 to 19 for Minecraft developers.